### PR TITLE
Expose the coingecko ID in the coinrank endpoint response

### DIFF
--- a/src/types.ts
+++ b/src/types.ts
@@ -25,6 +25,7 @@ export type CoinrankReq = ReturnType<typeof asCoinrankReq>
 // eslint-disable-next-line @typescript-eslint/explicit-function-return-type
 const asCoingeckoAsset = (raw: any) => {
   const asset = asObject({
+    id: asString,
     symbol: asString,
     name: asString,
     image: asString,
@@ -55,6 +56,7 @@ const asCoingeckoAsset = (raw: any) => {
   })(raw)
 
   const {
+    id,
     symbol,
     name,
     image,
@@ -83,6 +85,7 @@ const asCoingeckoAsset = (raw: any) => {
   } = asset
 
   const out = {
+    assetId: id,
     currencyCode: symbol,
     currencyName: name,
     imageUrl: image,


### PR DESCRIPTION
In order for the GUI to fetch the data required to draw a chart for an asset from the CoinRanking Scene (Markets tab), it needs to know of the unique id as defined by the asset market data source (CoinGecko).

This PR exposes that id which already exists in the response from CoinGecko.

---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1203924091043594