### PR TITLE
Fix CMC historical queries to go 5 years back

### DIFF
--- a/src/utils/utils.ts
+++ b/src/utils/utils.ts
@@ -208,3 +208,11 @@ export const createAssetMaps = async (
     mutexMap[func.name] = false
   }
 }
+
+export const daysBetween = (date1: Date, date2: Date): number => {
+  const oneDay = 24 * 60 * 60 * 1000 // One day in milliseconds
+  const diffDays = Math.round(
+    Math.abs((date2.getTime() - date1.getTime()) / oneDay)
+  )
+  return diffDays
+}


### PR DESCRIPTION
Use daily average if over 90 days old

### CHANGELOG

Query CMC historical rates with daily avg to allow 5 years of data

### Dependencies

<!-- Replace line with PRs which this PR depends if any --> none

### Description

<!-- Describe your changes textually and/or pictorially if necessary --> none


---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1204508232607833