### PR TITLE
Run rates engine at set intervals

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,5 @@
+# edge-rates-server
+
+## Unreleased
+
+- added: Run engines at configurable intervals and minute offset

--- a/src/config.ts
+++ b/src/config.ts
@@ -159,6 +159,18 @@ export const asConfig = asObject({
     'BTC_iso:INR'
   ]),
   defaultFiatCode: asOptional(asString, DEFAULT_FIAT),
+
+  /**
+   * Run the engine every n seconds after the hour
+   * and every n seconds of the hour
+   * */
+  coinrankIntervalSeconds: asOptional(asNumber, 120),
+  ratesIntervalSeconds: asOptional(asNumber, 60),
+
+  /** Offset the running of engine by n seconds */
+  coinrankOffsetSeconds: asOptional(asNumber, 0),
+  ratesOffsetSeconds: asOptional(asNumber, 0),
+
   ratesLookbackLimit: asOptional(asNumber, 604800000)
 })
 

--- a/src/utils/utils.ts
+++ b/src/utils/utils.ts
@@ -215,3 +215,20 @@ export const daysBetween = (date1: Date, date2: Date): number => {
   )
   return diffDays
 }
+
+export const getDelay = (params: {
+  now: Date
+  offsetSeconds: number
+  intervalSeconds: number
+}): number => {
+  const { now, intervalSeconds, offsetSeconds } = params
+  const intervalMs = intervalSeconds * 1000
+  const ms = now.getMilliseconds()
+  const s = now.getSeconds() - (offsetSeconds % 60)
+  const m = now.getMinutes() - Math.floor(offsetSeconds / 60)
+
+  const msSinceStartOfHour = m * 60000 + s * 1000 + ms
+  const delay = intervalMs - (msSinceStartOfHour % intervalMs)
+
+  return delay
+}

--- a/test/unitUtils.test.ts
+++ b/test/unitUtils.test.ts
@@ -3,7 +3,7 @@ import { describe, it } from 'mocha'
 
 import { asExchangeRateReq } from '../src/exchangeRateRouter'
 import { createThrottledMessage } from '../src/utils/createThrottledMessage'
-import { normalizeDate } from '../src/utils/utils'
+import { getDelay, normalizeDate } from '../src/utils/utils'
 import fixtures from './unitUtils.json'
 
 for (const test of fixtures.normalizeDate) {
@@ -90,3 +90,189 @@ for (const test of fixtures.asRateParam) {
     })
   })
 }
+
+describe(`getDelay tests`, function() {
+  it(`getDelay 1:30 0 15`, function() {
+    assert.equal(
+      getDelay({
+        now: new Date('2024-01-10T00:01:30.000Z'),
+        offsetSeconds: 0,
+        intervalSeconds: 15
+      }),
+      15000
+    )
+  })
+  it(`getDelay 1:35.100 0 15`, function() {
+    assert.equal(
+      getDelay({
+        now: new Date('2024-01-10T00:01:35.100Z'),
+        offsetSeconds: 0,
+        intervalSeconds: 15
+      }),
+      9900
+    )
+  })
+  it(`getDelay 1:29.999 0 120`, function() {
+    assert.equal(
+      getDelay({
+        now: new Date('2024-01-10T00:01:29.999Z'),
+        offsetSeconds: 0,
+        intervalSeconds: 120
+      }),
+      30001
+    )
+  })
+  it(`getDelay 1:29.999 60 120`, function() {
+    assert.equal(
+      getDelay({
+        now: new Date('2024-01-10T00:01:29.999Z'),
+        offsetSeconds: 60,
+        intervalSeconds: 120
+      }),
+      90001
+    )
+  })
+  it(`getDelay 51:30 0 120`, function() {
+    assert.equal(
+      getDelay({
+        now: new Date('2024-01-10T00:51:30.000Z'),
+        offsetSeconds: 0,
+        intervalSeconds: 120
+      }),
+      30000
+    )
+  })
+  it(`getDelay 51:29.999 0 120`, function() {
+    assert.equal(
+      getDelay({
+        now: new Date('2024-01-10T00:51:29.999Z'),
+        offsetSeconds: 0,
+        intervalSeconds: 120
+      }),
+      30001
+    )
+  })
+  it(`getDelay 51:29.999 60 120`, function() {
+    assert.equal(
+      getDelay({
+        now: new Date('2024-01-10T00:51:29.999Z'),
+        offsetSeconds: 60,
+        intervalSeconds: 120
+      }),
+      90001
+    )
+  })
+
+  it(`getDelay 1:30 0 180`, function() {
+    assert.equal(
+      getDelay({
+        now: new Date('2024-01-10T00:01:30.000Z'),
+        offsetSeconds: 0,
+        intervalSeconds: 180
+      }),
+      90000
+    )
+  })
+  it(`getDelay 1:29.999 0 180`, function() {
+    assert.equal(
+      getDelay({
+        now: new Date('2024-01-10T00:01:29.999Z'),
+        offsetSeconds: 0,
+        intervalSeconds: 180
+      }),
+      90001
+    )
+  })
+
+  it(`getDelay 51:29.999 60 180`, function() {
+    assert.equal(
+      getDelay({
+        now: new Date('2024-01-10T00:51:29.999Z'),
+        offsetSeconds: 60,
+        intervalSeconds: 180
+      }),
+      30001
+    )
+  })
+  it(`getDelay 58:29.999 60 180`, function() {
+    assert.equal(
+      getDelay({
+        now: new Date('2024-01-10T00:58:29.999Z'),
+        offsetSeconds: 60,
+        intervalSeconds: 180
+      }),
+      150001
+    )
+  })
+
+  it(`getDelay 58:29.999 0 30`, function() {
+    assert.equal(
+      getDelay({
+        now: new Date('2024-01-10T00:58:29.999Z'),
+        offsetSeconds: 0,
+        intervalSeconds: 30
+      }),
+      1
+    )
+  })
+  it(`getDelay 55:59.999 0 30`, function() {
+    assert.equal(
+      getDelay({
+        now: new Date('2024-01-10T00:55:59.999Z'),
+        offsetSeconds: 0,
+        intervalSeconds: 30
+      }),
+      1
+    )
+  })
+  it(`getDelay 59:59.999 0 30`, function() {
+    assert.equal(
+      getDelay({
+        now: new Date('2024-01-10T00:59:59.999Z'),
+        offsetSeconds: 0,
+        intervalSeconds: 30
+      }),
+      1
+    )
+  })
+  it(`getDelay 59:59.999 30 60`, function() {
+    assert.equal(
+      getDelay({
+        now: new Date('2024-01-10T00:59:59.999Z'),
+        offsetSeconds: 30,
+        intervalSeconds: 60
+      }),
+      30001
+    )
+  })
+  it(`getDelay 59:59.999 0 60`, function() {
+    assert.equal(
+      getDelay({
+        now: new Date('2024-01-10T00:59:59.999Z'),
+        offsetSeconds: 0,
+        intervalSeconds: 60
+      }),
+      1
+    )
+  })
+  it(`getDelay 58:09.999 30 60`, function() {
+    assert.equal(
+      getDelay({
+        now: new Date('2024-01-10T00:58:09.999Z'),
+        offsetSeconds: 30,
+        intervalSeconds: 60
+      }),
+      20001
+    )
+  })
+  it(`getDelay 58:09.999 0 60`, function() {
+    assert.equal(
+      getDelay({
+        now: new Date('2024-01-10T00:58:09.999Z'),
+        offsetSeconds: 0,
+        intervalSeconds: 60
+      }),
+      50001
+    )
+  })
+})


### PR DESCRIPTION
This allows multiple rates servers to run at different intervals with enough time to synchronize rates data between them.

ie. rates1 running every 2 minutes on odd minutes (1,3,5,7...). rates2 running every 2 minutes on even numbered minutes (0,2,4,6...)

This prevents redudant API calls to rates API services like Coingecko

### CHANGELOG

Does this branch warrant an entry to the CHANGELOG?

- [x] Yes
- [ ] No

### Dependencies

<!-- Replace line with PRs which this PR depends if any --> none

### Description

<!-- Describe your changes textually and/or pictorially if necessary --> none


---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1207077406387129