### PR TITLE
Fix: Non-USD coinrank requests returning USD results

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## Unreleased
 
+- fixed: Non-USD coinrank rate requests were intermittently returning USD results
 - fixed: `coinrank?fiatCode=iso:[fiatCode]` was not calculating fiat exchange rates for all relevant fields
 
 ## 0.2.0 (2024-04-16)


### PR DESCRIPTION
## Problem

Non-USD coinrank rate requests were intermittently returning USD results due to several issues in the implementation:

1. Improper data flow control - the function would unconditionally return whatever was in redisResult at the end, regardless of conversion success
2. Lack of validation for exchange rates
3. No error handling for API failures
4. No fallback mechanism for when conversion failed
5. Missing null checks before parsing Redis data

## Solution

This PR implements a comprehensive fix with:

- Better control flow with clear return paths for different scenarios
- Proper validation of exchange rates before calculations
- Comprehensive error handling with try/catch blocks
- Smart fallback strategy to use cached data when fresh conversion fails
- Proper null checks before parsing Redis data
- Added logging for error conditions to help with debugging

## Testing

Tested with various fiat code requests to ensure proper currency conversion and error handling.

## Changelog

- fixed: Non-USD coinrank rate requests were intermittently returning USD results

---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1209886504582592